### PR TITLE
Removing GitHub Copilot extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,7 @@
 		"vscode": {
 			"extensions": [
 				"rust-lang.rust-analyzer",
-				"vadimcn.vscode-lldb",
-				"GitHub.copilot-nightly"
+				"vadimcn.vscode-lldb"
 			]
 		}
 	},


### PR DESCRIPTION
The GitHub Copilot extension for Visual Studio Code is removed